### PR TITLE
Minor update to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ experiment file:
         "func": "swap_nodepool",
         "secrets": ["gcp"],
         "arguments": {
-            "body": {
+            "old_node_pool_id": "...",
+            "new_nodepool_body": {
                 "nodePool": {
                     "config": { 
                         "oauthScopes": [


### PR DESCRIPTION
Small update to the action config in the README file.  

From running an experiment and looking at the code in _actions.py_, it does appear that the "swap_nodepool" function requires the "old_node_pool_id" and "new_nodepool_body" parameters.