### PR TITLE
Added suspend/resume functions to compute action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-google-cloud-platform/compare/0.27.0...HEAD
 
+#### Added
+
+* `suspend_vm_instance` and `resume_vm_instance` functions to 
+* `chaosgcp.compute.actions`. These functions suspend a running
+* GCE VM instance and resume any suspended GCE VM respectively.
+* They can be called for action in experiments as follows:
+
+  ```json
+   {
+	"name" : "Suspend VM",
+	"type" : "action",
+        "provider": {
+            	"type": "python",
+		        "module": "chaosgcp.compute.actions",
+		        "func": "suspend_vm_instance",
+                "arguments" : {
+                    "project_id" : "prj-shared-ntwk-prod",
+                    "zone" : "us-central1-b",
+                    "instance_name" : "mig-exp-ig-24w1"
+                }
+            }
+        }
+* Added test cases for both the functions as well.
+
 ## [0.27.0][] - 2024-05-14
 
 [0.27.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-google-cloud-platform/compare/0.26.0...0.27.0

--- a/chaosgcp/compute/actions.py
+++ b/chaosgcp/compute/actions.py
@@ -1,5 +1,17 @@
-# Copyright 2023 Google LLC.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from typing import Any, Dict
 
@@ -62,3 +74,63 @@ def set_instance_tags(
     response = operation.result()
 
     return to_dict(response)
+
+
+def suspend_vm_instance(
+    project_id: str, zone: str, instance_name: str, secrets: Secrets = None
+):
+    """
+    Suspend a GCE VM instance
+
+    :param project_id : the project ID in which the GCE VM is present
+    :param zone: the name of the zone where the GCE VM is present
+    :param instance_name : the name of the GCE VM to be suspended
+    """
+
+    credentials = load_credentials(secrets)
+
+    # Create a client
+    client = compute_v1.InstancesClient(credentials=credentials)
+
+    # Make the request to delete
+    operation = client.suspend(
+        project=project_id, zone=zone, instance=instance_name
+    )
+
+    wait_on_extended_operation(operation)
+
+    if operation.error_code:
+        logger.error(
+            f"Error during instance suspension: [Code: {operation.error_code}]: {operation.error_message}"
+        )
+    else:
+        logger.info("Instance suspended successfully")
+
+
+def resume_vm_instance(
+    project_id: str, zone: str, instance_name: str, secrets: Secrets = None
+) -> Dict[str, Any]:
+    """
+    Resume a suspended GCE VM instance
+
+    :param project_id : the project ID in which the GCE VM is present
+    :param zone: the name of the zone where the GCE VM is present
+    :param instance_name : the name of the GCE VM to be resumed
+    """
+
+    credentials = load_credentials(secrets)
+
+    client = compute_v1.InstancesClient(credentials=credentials)
+
+    operation = client.resume(
+        project=project_id, zone=zone, instance=instance_name
+    )
+
+    wait_on_extended_operation(operation)
+
+    if operation.error_code:
+        logger.error(
+            f"Error during instance resumption: [Code: {operation.error_code}]: {operation.error_message}"
+        )
+    else:
+        logger.info("Instance resumed successfully")

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,5 +1,17 @@
-# Copyright 2023 Google LLC.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest.mock import MagicMock, patch
 from chaosgcp.compute.actions import compute_v1
 import fixtures
@@ -49,3 +61,39 @@ def test_set_instance_tags(Credentials, client, instance_req, settag_req, tags):
 
     client.set_tags.return_value = compute_v1.Operation(name="op1")
     client.set_tags(settag_req)
+
+
+@patch("chaosgcp.compute.actions.compute_v1.InstancesClient", autospec=True)
+@patch(
+    "chaosgcp.compute.actions.compute_v1.SuspendInstanceRequest", autospec=True
+)
+@patch("chaosgcp.Credentials", autospec=True)
+def test_suspend_vm_instance(Credentials, client, suspendvm_req):
+    project_id = fixtures.configuration["gcp_project_id"]
+    zone_name = fixtures.configuration["gcp_zone"]
+    instance_name = "test_instance"
+
+    client.return_value = MagicMock()
+    Credentials.from_service_account_file.return_value = MagicMock()
+
+    suspendvm_req.return_value = compute_v1.SuspendInstanceRequest(
+        instance=instance_name, project=project_id, zone=zone_name
+    )
+
+
+@patch("chaosgcp.compute.actions.compute_v1.InstancesClient", autospec=True)
+@patch(
+    "chaosgcp.compute.actions.compute_v1.SuspendInstanceRequest", autospec=True
+)
+@patch("chaosgcp.Credentials", autospec=True)
+def test_resume_vm_instance(Credentials, client, resumevm_req):
+    project_id = fixtures.configuration["gcp_project_id"]
+    zone_name = fixtures.configuration["gcp_zone"]
+    instance_name = "test_instance"
+
+    client.return_value = MagicMock()
+    Credentials.from_service_account_file.return_value = MagicMock()
+
+    resumevm_req.return_value = compute_v1.ResumeInstanceRequest(
+        instance=instance_name, project=project_id, zone=zone_name
+    )


### PR DESCRIPTION
PR to add suspend and resume functions for compute engine VMs. 
Added the `suspend_vm_instance` and `resume_vm_instance` functions to 
`chaosgcp.compute.actions`. These functions suspend a running GCE VM 
instance and resume any suspended GCE VM respectively. Added test cases 
for both the functions as well.