### PR TITLE
Fixes some typos in docstring

### DIFF
--- a/chaosgcp/apphub/actions.py
+++ b/chaosgcp/apphub/actions.py
@@ -221,11 +221,11 @@ def inject_fault_if_url_map_exists_app_hub(
         region (str): The region of the AppHub application.
         target_name (str): the the name of a path matcher in the URL map.
         target_path (str): default "/*",
-        impacted_percentage: float default 50.0,
-        http_status (int) default 400,
-        regional: (bool) default True,
-        configuration: (Configuration) default None,
-        secrets: (Secrets) default None,
+        impacted_percentage (float): default 50.0,
+        http_status (int): default 400,
+        regional (bool): default True,
+        configuration (Configuration): default None,
+        secrets (Secrets): default None,
     """
 
     if not url_map_exists(
@@ -282,8 +282,8 @@ def remove_fault_if_url_map_exists_app_hub(
         target_name (str): the the name of a path matcher in the URL map.
         target_path (str): default "/*",
         regional: (bool) default True,
-        configuration: (Configuration) default None,
-        secrets: (Secrets) default None,
+        configuration (Configuration): default None,
+        secrets (Secrets): default None,
     """
 
     if not url_map_exists(

--- a/chaosgcp/iam/controls/policy.py
+++ b/chaosgcp/iam/controls/policy.py
@@ -191,7 +191,6 @@ def manage_time_bound_temporary_iam_roles(
     Raises:
         TypeError: If any of the arguments are not of the expected type.
         ValueError: If `manage_type` is not "add" or "remove".
-        # (Add other potential exceptions based on your IAM implementation)
 
     Example:
         # Grant roles with a 15-minute expiration:


### PR DESCRIPTION
- Updated the docstring to follow the correct format for parameter type and description pairing with `:` separator in chaosgcp/apphub/actions.py (line 225):
- Removed the placeholder comment for adding potential exceptions in the future in chaosgcp/iam/controls/policy.py (line 194) as placeholder comments are not valid in the Raises section of a docstring